### PR TITLE
Support TLS connection.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-ytsaurus
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
This is a draft for supporting TLS connections in the provider.

I had to change go version because of the error:
```
# go.uber.org/multierr
../../go/pkg/mod/go.uber.org/multierr@v1.11.0/error.go:209:20: undefined: atomic.Bool
note: module requires Go 1.19
```

To work properly `yt.Config` should support a client CA. I patched it locally to add `Certs` field :
```go
clientConfig.Certs = []byte(config.ClusterCA.ValueString())
```

On the side of `a.yandex-team.ru/yt/go/yt/internal/httpclient/client.go` I added loading of the certificates:
```go
certPool, err := internal.NewCertPool()
if err != nil {
	return nil, err
}

if ok := certPool.AppendCertsFromPEM(c.Certs); !ok {
	return nil, errors.New("Failed to parse certificate")
}
```